### PR TITLE
fix: unhandled ex with long device names

### DIFF
--- a/MainForm.cs
+++ b/MainForm.cs
@@ -178,7 +178,7 @@ namespace MicMute
         private void UpdateIcon(Icon icon, string tooltipText)
         {
             this.icon.Icon = icon;
-            this.icon.Text = tooltipText.Substring(0, Math.Min(tooltipText.Length, 64));
+            this.icon.Text = tooltipText.Substring(0, Math.Min(tooltipText.Length, 63));
         }
 
         public async void ToggleMicStatus()


### PR DESCRIPTION
Actually, you tried to fix it at the correct location. Unfortunately, since a 64 char string is counted from 0 to 63, the max value had to be reduced by 1.

Could you please build a new package (v0.8.0) including this fix and add it to GitHub Releases?

Resolves: #25
